### PR TITLE
Removal of non-C3 keywords, add of assert, bitstruct, foreach, distin…

### DIFF
--- a/syntax/c3.vim
+++ b/syntax/c3.vim
@@ -2,49 +2,50 @@ if exists("b:current_syntax")
   finish
 endif
 
-syntax keyword c3As as 
-syntax keyword c3Auto auto 
-syntax keyword c3Asm asm 
-syntax keyword c3Attribute attribute 
-syntax keyword c3Break break 
-syntax keyword c3Case case 
-syntax keyword c3Cast cast 
+syntax keyword c3Asm asm
+syntax keyword c3Assert assert
+syntax keyword c3Attribute attribute
+syntax keyword c3Bitstruct bitstruct
+syntax keyword c3Break break
+syntax keyword c3Case case
 syntax keyword c3Catch catch 
 syntax keyword c3Const const 
 syntax keyword c3Continue continue 
-syntax keyword c3Default default 
+syntax keyword c3Def def
+syntax keyword c3Default default
 syntax keyword c3Defer defer 
 syntax keyword c3Define define 
-syntax keyword c3Do do 
+syntax keyword c3Distinct distinct
+syntax keyword c3Do do
 syntax keyword c3Else else 
 syntax keyword c3Enum enum 
-syntax keyword c3Errtype errtype 
-syntax keyword c3For for 
+syntax keyword c3Extern extern
+syntax keyword c3Fault fault
+syntax keyword c3For for
+syntax keyword c3Foreach foreach
+syntax keyword c3Foreachr foreach_r
 syntax keyword c3Fn fn 
-syntax keyword c3Generic generic 
-syntax keyword c3If if 
-syntax keyword c3Import import 
+syntax keyword c3If if
+syntax keyword c3Import import
+syntax keyword c3Inline inline
 syntax keyword c3Local local
 syntax keyword c3Macro macro 
 syntax keyword c3Module module 
-syntax keyword c3Nextcase nextcase 
-syntax keyword c3Private private
-syntax keyword c3Return return 
+syntax keyword c3Nextcase nextcase
+syntax keyword c3Return return
+syntax keyword c3Static static
 syntax keyword c3Struct struct 
-syntax keyword c3Switch switch 
-syntax keyword c3Throw throw 
-syntax keyword c3Throws throws 
-syntax keyword c3Try try 
-syntax keyword c3Type type 
-syntax keyword c3Union union 
-syntax keyword c3Until until 
+syntax keyword c3Switch switch
+syntax keyword c3Tlocal tlocal
+syntax keyword c3Try try
+syntax keyword c3Union union
 syntax keyword c3Var var 
 syntax keyword c3Void void 
 syntax keyword c3While while 
 
-syntax keyword c3DataType float double char bool byte short ushort int uint long ulong isz usz
+syntax keyword c3DataType float double char bool byte short ushort int uint long ulong isz usz iptr uptr int128 uint128 float16 float128 typeid any anyfault
 syntax keyword c3Bool true false
-syntax keyword c3Null nil
+syntax keyword c3Null null
 
 syntax match c3Todo "TODO"
 syntax match c3Note "NOTE"
@@ -56,7 +57,7 @@ syntax match c3Hack "HACK"
 syntax region c3RawString start=+`+ end=+`+
 syntax region c3Char start=+'+ skip=+\\\\\|\\'+ end=+'+
 syntax region c3String start=+"+ skip=+\\\\\|\\'+ end=+"+ contains=c3Escape
-syntax match c3Escape display contained /\\\([nrt\\'"]\|x\x\{2}\)/
+syntax match c3Escape display contained /\\\([nrtabe0\\'"]\|x\x\{2}\)/
 
 syntax match c3FunctionDecl "fn\v<\w*>(\s*\s*)@="
 syntax match c3FunctionCall "\v\w+\s*(\()@="
@@ -65,14 +66,12 @@ syntax match c3TagNote "@\<\w\+\>" display
 
 syntax match c3Constant "\v<[A-Z0-9,_]+>" display
 syntax match c3Range "\.\." display
-syntax match c3HalfRange "\.\.\<" display
 syntax match c3TernaryQMark "?" display
 syntax match c3DeclAssign "=" display
 
 syntax match c3Integer "\-\?\<\d\+\>" display
 syntax match c3Float "\-\?\<[0-9][0-9_]*\%(\.[0-9][0-9_]*\)\%([eE][+-]\=[0-9_]\+\)\=" display
 syntax match c3Hex "\<0[xX][0-9A-Fa-f]\+\>" display
-syntax match c3Doz "\<0[zZ][0-9a-bA-B]\+\>" display
 syntax match c3Oct "\<0[oO][0-7]\+\>" display
 syntax match c3Bin "\<0[bB][01]\+\>" display
 
@@ -87,38 +86,33 @@ syntax match c3CommentNote "@\<\w\+\>" contained display
 syntax region c3LineComment start=/\/\// end=/$/  contains=c3CommentNote, c3Todo, c3Note, c3XXX, c3FixMe, c3NoCheckin, c3Hack
 syntax region c3BlockComment start=/\v\/\*/ end=/\v\*\// contains=c3BlockComment, c3CommentNote, c3Todo, c3Note, c3XXX, c3FixMe, c3NoCheckin, c3Hack
 
-
-
-highlight link c3As Keyword
-highlight link c3Auto Keyword
 highlight link c3Asm Keyword
+highlight link c3Assert Keyword
 highlight link c3Attribute Keyword
 highlight link c3Break Keyword
 highlight link c3Case Keyword
-highlight link c3Cast Keyword
 highlight link c3Catch Keyword
 highlight link c3Const Keyword
 highlight link c3Continue Keyword
 highlight link c3Default Keyword
+highlight link c3Def Keyword
 highlight link c3Defer Keyword
 highlight link c3Define Keyword
+highlight link c3Distinct Keyword
 highlight link c3Do Keyword
-highlight link c3Errtype Keyword
+highlight link c3Extern Keyword
 highlight link c3Fn Keyword
-highlight link c3Generic Keyword
 highlight link c3Import Keyword
+highlight link c3Inline Keyword
 highlight link c3Local Keyword
 highlight link c3Macro Keyword
 highlight link c3Module Keyword
 highlight link c3Nextcase Keyword
-highlight link c3Private Keyword
 highlight link c3Return Keyword
+highlight link c3Static Keyword
 highlight link c3Switch Keyword
-highlight link c3Throw Keyword
-highlight link c3Throws Keyword
+highlight link c3Tlocal Keyword
 highlight link c3Try Keyword
-highlight link c3Type Keyword
-highlight link c3Until Keyword
 highlight link c3Var Keyword
 highlight link c3Void Keyword
 highlight link c3While Keyword
@@ -136,7 +130,9 @@ highlight link c3Char String
 
 highlight link c3Struct Structure
 highlight link c3Enum Structure
+highlight link c3Fault Structure
 highlight link c3Union Structure
+highlight link c3Bitstruct Structure
 
 " :FunctionHighlighting
 highlight link c3FunctionDecl Function
@@ -146,6 +142,8 @@ highlight link c3Macro Macro
 highlight link c3If Conditional
 highlight link c3Else Conditional
 highlight link c3For Repeat
+highlight link c3Foreach Repeat
+highlight link c3Foreachr Repeat
 
 highlight link c3LineComment Comment
 highlight link c3BlockComment Comment
@@ -170,6 +168,5 @@ highlight link c3Float Float
 highlight link c3Hex Number
 highlight link c3Oct Number
 highlight link c3Bin Number
-highlight link c3Doz Number
 
 let b:current_syntax = "c3"


### PR DESCRIPTION
…ct, inline, static, tlocal, iptr, uptr, int128, uint128, null, typeid, any, anyfault, removed "half range", extended escapes.

Some missing stuff:
- \u012f and \U0123fabc escape sequences should be added for strings.
- Double \`\` converts to a single, non-terminating, \` in raw strings.
- C3 has two ranges, the inclusive `a..b` and the start-length: `a:b`. This latter doesn't seem supported.
- Optional types are the regular type names suffixed with `!`, e.g. `int!`
- There is normal C ternary, i.e. `a ? b : c` but also the binary `a ?: b` and `a ?? b` (the last one is same as Odin's or_else)
- Floats also accept hex notation, e.g. `0x34p-12`
- Numerical suffixes are: `u` `ul` `l` and `i<bitsize>` `u<bitsize>`

Compile time keywords seem to be missing:
$alignof, $assert, $case, $checks, $default, $defined, $echo, $else, $endfor, $endforeach, $endif, $endswitch, $error, $eval, $evaltype, $extnameof, $for, $foreach, $if, $include, $nameof, $sizeof, $stringify, $switch, $typeof, $typefrom, $qnameof, $vacount, $vaconst, $vatype, $vaarg, $varef, $vaexpr, $vasplat